### PR TITLE
feat: Set hostname via ICECAST_HOSTNAME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $BROWSER localhost:8000
 Run with custom password
 
 ```bash
-docker run -p 8000:8000 -e ICECAST_SOURCE_PASSWORD=aaaa -e ICECAST_ADMIN_PASSWORD=bbbb -e ICECAST_PASSWORD=cccc -e ICECAST_RELAY_PASSWORD=dddd moul/icecast
+docker run -p 8000:8000 -e ICECAST_SOURCE_PASSWORD=aaaa -e ICECAST_ADMIN_PASSWORD=bbbb -e ICECAST_PASSWORD=cccc -e ICECAST_RELAY_PASSWORD=dddd -e ICECAST_HOSTNAME=noise.example.com -emoul/icecast
 ```
 
 Run with custom configuration
@@ -46,6 +46,7 @@ icecast:
   - ICECAST_ADMIN_PASSWORD=bbb
   - ICECAST_PASSWORD=ccc
   - ICECAST_RELAY_PASSWORD=ddd
+  - ICECAST_HOSTNAME=noise.example.com
   ports:
   - 8000:8000
 ```

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,7 @@ set_val $ICECAST_SOURCE_PASSWORD source-password
 set_val $ICECAST_RELAY_PASSWORD  relay-password
 set_val $ICECAST_ADMIN_PASSWORD  admin-password
 set_val $ICECAST_PASSWORD        password
+set_val $ICECAST_HOSTNAME        hostname
 
 set -e
 


### PR DESCRIPTION
Previously the downloadable .m3u and .xspf always pointed at http://localhost:8000/mountname .. with this change the correct hostname can be set via the ICECAST_HOSTNAME variable.