### PR TITLE
build: Add alpine-based docker image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,12 @@
+FROM alpine
+
+RUN apk add --no-cache icecast mailcap
+RUN mkdir /etc/icecast \
+    && chown icecast:icecast /etc/icecast
+
+ADD ./start-alpine.sh /start.sh
+USER icecast
+
+EXPOSE 8000
+VOLUME ["/var/log/icecast"]
+CMD ["/start.sh"]

--- a/start-alpine.sh
+++ b/start-alpine.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+env
+
+set -x
+
+set_val() {
+    if [ -n "$2" ]; then
+        echo "set '$2' to '$1'"
+        sed -i "s/<$2>[^<]*<\/$2>/<$2>$1<\/$2>/g" /etc/icecast/icecast.xml
+    else
+        echo "Setting for '$1' is missing, skipping." >&2
+    fi
+}
+
+cp /etc/icecast.xml /etc/icecast/
+
+set_val $ICECAST_SOURCE_PASSWORD source-password
+set_val $ICECAST_RELAY_PASSWORD  relay-password
+set_val $ICECAST_ADMIN_PASSWORD  admin-password
+set_val $ICECAST_PASSWORD        password
+set_val $ICECAST_HOSTNAME        hostname
+
+set -e
+
+icecast -c /etc/icecast/icecast.xml


### PR DESCRIPTION
This adds an alternate Dockerfile and start script for an alpine-based image using the official alpine icecast package.

Building upon alpine not only reduces the image size (from 229MB to 11.6MB) but also the attack surface.
For the current image, [trivy](https://github.com/aquasecurity/trivy) reports 239 vulnerabilities (5 of which are critical, 54 high) whereas the alpine-based one is only affected by 4 medium ones.