### PR TITLE
Remove python-setuptools from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq -y update; \
   apt-get -qq -y full-upgrade; \ 
-  apt-get -qq -y install icecast2 python-setuptools sudo cron-apt; \
+  apt-get -qq -y install icecast2 sudo cron-apt; \
   apt-get -y autoclean; \
   apt-get clean; \
   chown -R icecast2 /etc/icecast2; \


### PR DESCRIPTION
This change is required for the image to build under the latest version of Debian. See issue #22.